### PR TITLE
ovirt: install.sh - do not generate CONNECTION_URI by default

### DIFF
--- a/pkg/ovirt/components/InstallationDialog.jsx
+++ b/pkg/ovirt/components/InstallationDialog.jsx
@@ -149,6 +149,7 @@ function configureOvirtUrl(oVirtFqdn, oVirtPort) {
 
 function doRegisterOvirt(oVirtFqdn, oVirtPort, dfd) {
     console.info('configureOvirtUrl() - oVirt engine connection can be established', oVirtFqdn, oVirtPort);
+    // CONNECTION URI is not passed as an argument here, so oVirt default will be farther used - see configFuncs.es6:readConfiguration()
     cockpit.spawn(['bash', INSTALL_SH, oVirtFqdn, oVirtPort], {"superuser": "try"})
             .done(function () {
                 console.info('oVirt installation script was successful');

--- a/pkg/ovirt/configFuncs.es6
+++ b/pkg/ovirt/configFuncs.es6
@@ -37,15 +37,18 @@ export function readConfiguration ({ dispatch }) {
     promises.push(doReadHostname({ dispatch }));
     promises.push(doReadIpAddresses({ dispatch }));
 
-    return cockpit.all(promises).done(function () {
-        // If hostname was found by doReadHostname() and VIRSH_CONNECTION_URI wasn't set in CONFIG_FILE
-        // (or CONFIG_FILE wasn't created) then auto calculate the Virsh connection URI as:
-        // qemu+tls://${hostName}/system
-        if (CONFIG.hostName && MACHINES_CONFIG.Virsh && MACHINES_CONFIG.Virsh.connections &&
-                Object.getOwnPropertyNames(MACHINES_CONFIG.Virsh.connections).indexOf('remote') === -1) {
-            MACHINES_CONFIG.Virsh.connections = {'remote': { params: ['-c', `qemu+tls://${CONFIG.hostName}/system`] }};
-        }
-    });
+    return cockpit.all(promises).done(setDefaultLibvirtConnection);
+}
+
+function setDefaultLibvirtConnection () {
+    // If hostname was found by doReadHostname() and VIRSH_CONNECTION_URI wasn't set in CONFIG_FILE
+    // (or CONFIG_FILE wasn't created) then auto calculate the Virsh connection URI as:
+    // qemu+tls://${hostName}/system
+    if (CONFIG.hostName && MACHINES_CONFIG.Virsh && MACHINES_CONFIG.Virsh.connections &&
+        Object.getOwnPropertyNames(MACHINES_CONFIG.Virsh.connections).indexOf('remote') === -1) {
+        MACHINES_CONFIG.Virsh.connections = {'remote': { params: ['-c', `qemu+tls://${CONFIG.hostName}/system`] }};
+    }
+    console.info('Libvirt connections to be used: ', JSON.stringify(MACHINES_CONFIG.Virsh));
 }
 
 /**

--- a/pkg/ovirt/install.sh
+++ b/pkg/ovirt/install.sh
@@ -67,17 +67,7 @@ function generateProviderConfig() {
         > ${CONFIG_FILE} || exit ${EXIT_NO_ACCESS_MACHINES_OVIRT_CONFIG}
 
   if [ x${VIRSH_CONNECTION_URI} = x ] ; then
-    echo " \
-        \"Virsh\": { \
-            \"connections\": { \
-                \"system\": { \
-                    \"params\": [\"-c\", \"qemu:///system\"] \
-                }, \
-                \"session\": { \
-                    \"params\": [\"-c\", \"qemu:///session\"] \
-                } \
-            } \
-        }" >> ${CONFIG_FILE}
+    echo \"___info\": \"Default oVirt remote connection will be used\" >> ${CONFIG_FILE}
   else
     echo " \
         \"Virsh\": { \


### PR DESCRIPTION
With this change, the oVirt default Libvirt URI is always used
unless explicitely configured in the machines-ovirt.config .

---

More info: https://github.com/cockpit-project/cockpit/pull/9226